### PR TITLE
updated javascript callback signing

### DIFF
--- a/pages/CallbackSigning.md
+++ b/pages/CallbackSigning.md
@@ -39,7 +39,7 @@ def callback():
 const API_SECRET = "Agegb...";
 
 function verifyPostData(req, res, next) {
-    const payload = JSON.stringify(req.body)
+    const payload = req.rawBody;
     
     if (!payload) {
       return next('Request body empty.')


### PR DESCRIPTION
The req.body should not be serialized at all. Plus the req.body is not a buffer so throws an error. Using req.rawBody (which is a buffer) works as intended.